### PR TITLE
Remove ethereum from ChainSelector

### DIFF
--- a/apps/web/src/components/Logo/ChainLogo.tsx
+++ b/apps/web/src/components/Logo/ChainLogo.tsx
@@ -1,20 +1,11 @@
-import { ChainId } from '@uniswap/sdk-core'
+import { ChainId } from '@hemilabs/sdk-core'
 import { getChainInfo } from 'constants/chainInfo'
 import { isSupportedChain, SupportedInterfaceChain } from 'constants/chains'
 import { CSSProperties, FunctionComponent } from 'react'
 import { useTheme } from 'styled-components'
 import { useIsDarkMode } from 'theme/components/ThemeToggle'
 
-import { ReactComponent as arbitrum } from './ChainSymbols/arbitrum.svg'
-import { ReactComponent as avax } from './ChainSymbols/avax.svg'
-import { ReactComponent as base } from './ChainSymbols/base.svg'
-import { ReactComponent as bnb } from './ChainSymbols/bnb.svg'
-import { ReactComponent as celo } from './ChainSymbols/celo.svg'
-import { ReactComponent as celoLight } from './ChainSymbols/celo_light.svg'
-import { ReactComponent as ethereum } from './ChainSymbols/ethereum.svg'
 import { ReactComponent as hemi } from './ChainSymbols/hemi.svg'
-import { ReactComponent as optimism } from './ChainSymbols/optimism.svg'
-import { ReactComponent as polygon } from './ChainSymbols/polygon.svg'
 
 type SVG = FunctionComponent<React.SVGProps<SVGSVGElement>>
 type ChainUI = { Symbol: SVG; bgColor: string; textColor: string }
@@ -22,12 +13,6 @@ type ChainUI = { Symbol: SVG; bgColor: string; textColor: string }
 export function getChainUI(chainId: SupportedInterfaceChain, darkMode: boolean): ChainUI
 export function getChainUI(chainId: ChainId): ChainUI | undefined {
   switch (chainId) {
-    case ChainId.MAINNET:
-      return {
-        Symbol: ethereum,
-        bgColor: '#6B8AFF33',
-        textColor: '#6B8AFF',
-      }
     case ChainId.HEMI_SEPOLIA:
       return {
         Symbol: hemi,

--- a/apps/web/src/components/Logo/ChainLogo.tsx
+++ b/apps/web/src/components/Logo/ChainLogo.tsx
@@ -1,4 +1,4 @@
-import { ChainId } from '@hemilabs/sdk-core'
+import { ChainId } from '@uniswap/sdk-core'
 import { getChainInfo } from 'constants/chainInfo'
 import { isSupportedChain, SupportedInterfaceChain } from 'constants/chains'
 import { CSSProperties, FunctionComponent } from 'react'

--- a/apps/web/src/components/swap/SwapHeader.tsx
+++ b/apps/web/src/components/swap/SwapHeader.tsx
@@ -11,7 +11,6 @@ import { useCallback, useEffect } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
 import { RowBetween, RowFixed } from '../Row'
 import SettingsTab from '../Settings'
-import SwapBuyFiatButton from './SwapBuyFiatButton'
 import { SwapTab } from './constants'
 import { SwapHeaderTabButton } from './styled'
 
@@ -105,7 +104,6 @@ export default function SwapHeader({ compact, syncTabToUrl }: { compact: boolean
             <Trans>Send</Trans>
           </SwapHeaderTabButton>
         )}
-        <SwapBuyFiatButton />
       </HeaderButtonContainer>
       {currentTab === SwapTab.Swap && (
         <RowFixed>

--- a/apps/web/src/connection/index.ts
+++ b/apps/web/src/connection/index.ts
@@ -203,7 +203,7 @@ const [web3CoinbaseWallet, web3CoinbaseWalletHooks] = initializeConnector<Coinba
     new CoinbaseWallet({
       actions,
       options: {
-        url: APP_RPC_URLS[ChainId.HEMI_SEPOLIA][0],
+        url: APP_RPC_URLS[DEFAULT_CHAIN_ID][0],
         appName: 'Uniswap',
         appLogoUrl: UNISWAP_LOGO,
         reloadOnDisconnect: false,

--- a/apps/web/src/connection/index.ts
+++ b/apps/web/src/connection/index.ts
@@ -21,6 +21,8 @@ import { Connection, ConnectionType, ProviderInfo } from './types'
 import { getDeprecatedInjection, getIsCoinbaseWallet, getIsInjected, getIsMetaMaskWallet } from './utils'
 import { UniwalletConnect as UniwalletWCV2Connect, WalletConnectV2 } from './WalletConnectV2'
 
+const DEFAULT_CHAIN_ID = ChainId.HEMI_SEPOLIA
+
 function onError(error: Error) {
   console.debug(`web3-react error: ${error}`)
 }
@@ -59,7 +61,7 @@ export const eip6963Connection: InjectedConnection = {
 }
 
 const [web3Network, web3NetworkHooks] = initializeConnector<Network>(
-  (actions) => new Network({ actions, urlMap: RPC_PROVIDERS, defaultChainId: 1 })
+  (actions) => new Network({ actions, urlMap: RPC_PROVIDERS, defaultChainId: DEFAULT_CHAIN_ID })
 )
 export const networkConnection: Connection = {
   getProviderInfo: () => ({ name: 'Network' }),
@@ -74,7 +76,7 @@ const [deprecatedWeb3Network, deprecatedWeb3NetworkHooks] = initializeConnector<
     new Network({
       actions,
       urlMap: DEPRECATED_RPC_PROVIDERS,
-      defaultChainId: 1,
+      defaultChainId: DEFAULT_CHAIN_ID,
     })
 )
 export const deprecatedNetworkConnection: Connection = {
@@ -120,7 +122,7 @@ export const gnosisSafeConnection: Connection = {
 }
 
 export const walletConnectV2Connection: Connection = new (class implements Connection {
-  private initializer = (actions: Actions, defaultChainId = ChainId.MAINNET) =>
+  private initializer = (actions: Actions, defaultChainId = DEFAULT_CHAIN_ID) =>
     new WalletConnectV2({ actions, defaultChainId, onError })
 
   type = ConnectionType.WALLET_CONNECT_V2
@@ -201,7 +203,7 @@ const [web3CoinbaseWallet, web3CoinbaseWalletHooks] = initializeConnector<Coinba
     new CoinbaseWallet({
       actions,
       options: {
-        url: APP_RPC_URLS[ChainId.MAINNET][0],
+        url: APP_RPC_URLS[ChainId.HEMI_SEPOLIA][0],
         appName: 'Uniswap',
         appLogoUrl: UNISWAP_LOGO,
         reloadOnDisconnect: false,


### PR DESCRIPTION
This removes Ethereum from the ChainSelector and leaves only **Hemi Sepolia**.

<img width="1511" alt="Captura de pantalla 2024-04-15 a la(s) 09 49 33" src="https://github.com/hemilabs/interface/assets/1864435/065d773a-0091-4b82-8dea-ce62981e5496">

It also removes the "buy" tab. It just hides the button, the whole feature's components are still available if needed in the future.
Regarding the "limit" tab, it appears to be under a feature flag, and disabled, I left it like that.
