### PR TITLE
Fix yarn install deps on deployment

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -20,7 +20,7 @@ jobs:
           node-version-file: .nvmrc
 
       - name: Install Dependencies
-        run: yarn install --immutable --immutable-cache
+        run: yarn install --immutable
 
       - name: Build site
         run: |


### PR DESCRIPTION
Last [build](https://github.com/hemilabs/interface/actions/runs/8818021531/job/24205843728) failed again, lets remove the `--immutable-cache` option.