### PR TITLE
Fix api url for production environment

### DIFF
--- a/apps/web/.env.production
+++ b/apps/web/.env.production
@@ -6,7 +6,7 @@ REACT_APP_BNB_RPC_URL="https://old-wispy-arrow.bsc.quiknode.pro/f5c060177236065c
 REACT_APP_FIREBASE_KEY="AIzaSyBcZWwTcTJHj_R6ipZcrJkXdq05PuX0Rs0"
 REACT_APP_FORTMATIC_KEY="pk_live_F937DF033A1666BF"
 REACT_APP_GOOGLE_ANALYTICS_ID="G-KDP9B6W4H8"
-REACT_APP_HEMI_UNISWAP_API_URL="https://hgc8sm30t0.execute-api.eu-central-1.amazonaws.com/production/v2/quote"
+REACT_APP_HEMI_UNISWAP_API_URL="https://hgc8sm30t0.execute-api.eu-central-1.amazonaws.com/production/v2"
 REACT_APP_INFURA_KEY="099fc58e0de9451d80b18d7c74caa7c1"
 REACT_APP_MOONPAY_API="https://api.moonpay.com"
 REACT_APP_MOONPAY_LINK="https://us-central1-uniswap-mobile.cloudfunctions.net/signMoonpayLinkV2?platform=web&env=production"


### PR DESCRIPTION
We were getting requests like `https://hgc8sm30t0.execute-api.eu-central-1.amazonaws.com/production/v2/quote/quote`.

This PR removes the extra `/quote`.

This change, along with https://github.com/hemilabs/routing-api/pull/9 should allow the app to query the api without issues.