### PR TITLE
Change homepage to /swap

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -3,7 +3,7 @@
   "version": "1.1.0",
   "description": "Uniswap Interface",
   "license": "GPL-3.0-or-later",
-  "homepage": "/uniswap",
+  "homepage": "/swap",
   "scripts": {
     "ajv": "node scripts/compile-ajv-validators.js",
     "check:deps:usage": "depcheck",


### PR DESCRIPTION
#21 missed changing the homepage config in package.json for CRA to work under /swap subdirectory.

Related to https://github.com/hemilabs/interface/issues/20