### PR TITLE
Fix disabling dark mode

### DIFF
--- a/apps/web/src/theme/components/ThemeToggle.tsx
+++ b/apps/web/src/theme/components/ThemeToggle.tsx
@@ -64,10 +64,11 @@ export function ThemeColorMetaUpdater() {
 }
 
 export function useIsDarkMode(): boolean {
-  const mode = useAtomValue(themeModeAtom)
+  return false // TODO: Remove line when dark mode is completed ref: https://github.com/hemilabs/interface/issues/16
+  /*const mode = useAtomValue(themeModeAtom)
   const systemTheme = useAtomValue(systemThemeAtom)
 
-  return (mode === ThemeMode.AUTO ? systemTheme : mode) === ThemeMode.DARK
+  return (mode === ThemeMode.AUTO ? systemTheme : mode) === ThemeMode.DARK*/
 }
 
 export function useDarkModeManager(): [boolean, (mode: ThemeMode) => void] {

--- a/apps/web/src/theme/index.tsx
+++ b/apps/web/src/theme/index.tsx
@@ -143,9 +143,7 @@ function applyOverriddenColors(defaultColors: ThemeColors, overriddenColors?: Pa
 }
 
 export function ThemeProvider({ children, ...overriddenColors }: PropsWithChildren<Partial<ThemeColors>>) {
-  //const darkMode = useIsDarkMode()
-  // TODO: Enable when dark mode is completed ref: https://github.com/hemilabs/interface/issues/16
-  const darkMode = false
+  const darkMode = useIsDarkMode()
 
   // eslint-disable-next-line react-hooks/exhaustive-deps -- only update when darkMode or overriddenColors' entries change
   const themeObject = useMemo(() => getTheme(darkMode, overriddenColors), [darkMode, JSON.stringify(overriddenColors)])


### PR DESCRIPTION
Some dark mode styles were still visible if the user has dark mode selected from system or browser settings.
<img width="1496" alt="Captura de pantalla 2024-05-03 a la(s) 15 41 48" src="https://github.com/hemilabs/interface/assets/1864435/978ff62d-fa2d-4ea2-bd85-075e6be3ecb6">

There was a previous fix for this [here](https://github.com/hemilabs/interface/pull/17), but that wasn't enough. This PR returns `false` from `useIsDarkMode()` hook, so it will be disabled everywhere it's called.