### PR TITLE
Fetch tokens from hemi testnet's tokenlist

### DIFF
--- a/apps/web/src/constants/chainInfo.ts
+++ b/apps/web/src/constants/chainInfo.ts
@@ -3,7 +3,15 @@ import ms from 'ms'
 import { darkTheme } from 'theme/colors'
 
 import { SupportedL1ChainId, SupportedL2ChainId } from './chains'
-import { ARBITRUM_LIST, AVALANCHE_LIST, BASE_LIST, CELO_LIST, OPTIMISM_LIST, PLASMA_BNB_LIST } from './lists'
+import {
+  ARBITRUM_LIST,
+  AVALANCHE_LIST,
+  BASE_LIST,
+  CELO_LIST,
+  HEMI_TESTNET_LIST,
+  OPTIMISM_LIST,
+  PLASMA_BNB_LIST,
+} from './lists'
 
 export const AVERAGE_L1_BLOCK_TIME = ms(`12s`)
 export const DEFAULT_MS_BEFORE_WARNING = ms(`10m`)
@@ -248,7 +256,7 @@ const CHAIN_INFO: ChainInfoMap = {
     networkType: NetworkType.L2,
     blockWaitMsBeforeWarning: ms(`25m`),
     bridge: 'http://app.hemi.xyz',
-    defaultListUrl: BASE_LIST,
+    defaultListUrl: HEMI_TESTNET_LIST,
     docs: 'https://docs.hemi.xyz',
     explorer: 'https://testnet.explorer.hemi.xyz',
     infoLink: 'https://docs.hemi.xyz/',
@@ -256,8 +264,6 @@ const CHAIN_INFO: ChainInfoMap = {
     statusPage: 'https://optimism.io/status',
     helpCenterUrl: 'https://docs.hemi.xyz',
     nativeCurrency: { name: 'Testnet Hemi Ether', symbol: 'thETH', decimals: 18 },
-    color: darkTheme.chain_10,
-    backgroundColor: darkTheme.chain_10_background,
   },
 } as const
 

--- a/apps/web/src/constants/lists.ts
+++ b/apps/web/src/constants/lists.ts
@@ -1,22 +1,5 @@
 export const UNI_LIST = 'https://cloudflare-ipfs.com/ipns/tokens.uniswap.org'
 export const UNI_EXTENDED_LIST = 'https://cloudflare-ipfs.com/ipns/extendedtokens.uniswap.org'
-const UNI_UNSUPPORTED_LIST = 'https://cloudflare-ipfs.com/ipns/unsupportedtokens.uniswap.org'
-const AAVE_LIST = 'tokenlist.aave.eth'
-const BA_LIST = 'https://raw.githubusercontent.com/The-Blockchain-Association/sec-notice-list/master/ba-sec-list.json'
-// TODO(WEB-2282): Re-enable CMC list once we have a better solution for handling large lists.
-// const CMC_ALL_LIST = 'https://s3.coinmarketcap.com/generated/dex/tokens/eth-tokens-all.json'
-const COINGECKO_LIST = 'https://tokens.coingecko.com/uniswap/all.json'
-const COINGECKO_BNB_LIST = 'https://tokens.coingecko.com/binance-smart-chain/all.json'
-const COINGECKO_ARBITRUM_LIST = 'https://tokens.coingecko.com/arbitrum-one/all.json'
-const COINGECKO_OPTIMISM_LIST = 'https://tokens.coingecko.com/optimistic-ethereum/all.json'
-const COINGECKO_CELO_LIST = 'https://tokens.coingecko.com/celo/all.json'
-const COINGECKO_POLYGON_LIST = 'https://tokens.coingecko.com/polygon-pos/all.json'
-const COINGECKO_AVAX_LIST = 'https://tokens.coingecko.com/avalanche/all.json'
-const COMPOUND_LIST = 'https://raw.githubusercontent.com/compound-finance/token-list/master/compound.tokenlist.json'
-const GEMINI_LIST = 'https://www.gemini.com/uniswap/manifest.json'
-const KLEROS_LIST = 't2crtokens.eth'
-const SET_LIST = 'https://raw.githubusercontent.com/SetProtocol/uniswap-tokenlist/main/set.tokenlist.json'
-const WRAPPED_LIST = 'wrapped.tokensoft.eth'
 
 export const OPTIMISM_LIST = 'https://static.optimism.io/optimism.tokenlist.json'
 export const ARBITRUM_LIST = 'https://bridge.arbitrum.io/token-list-42161.json'
@@ -26,34 +9,12 @@ export const AVALANCHE_LIST =
   'https://raw.githubusercontent.com/ava-labs/avalanche-bridge-resources/main/token_list.json'
 export const BASE_LIST =
   'https://raw.githubusercontent.com/ethereum-optimism/ethereum-optimism.github.io/master/optimism.tokenlist.json'
+export const HEMI_TESTNET_LIST = 'https://raw.githubusercontent.com/hemilabs/interface/main/hemi-testnet.tokenlist.json'
 
-export const UNSUPPORTED_LIST_URLS: string[] = [BA_LIST, UNI_UNSUPPORTED_LIST]
+export const UNSUPPORTED_LIST_URLS: string[] = []
 
 // default lists to be 'active' aka searched across
-export const DEFAULT_ACTIVE_LIST_URLS: string[] = [UNI_LIST]
-export const DEFAULT_INACTIVE_LIST_URLS: string[] = [
-  UNI_EXTENDED_LIST,
-  COMPOUND_LIST,
-  AAVE_LIST,
-  //  CMC_ALL_LIST,
-  COINGECKO_LIST,
-  COINGECKO_BNB_LIST,
-  COINGECKO_ARBITRUM_LIST,
-  COINGECKO_OPTIMISM_LIST,
-  COINGECKO_CELO_LIST,
-  COINGECKO_POLYGON_LIST,
-  COINGECKO_AVAX_LIST,
-  KLEROS_LIST,
-  GEMINI_LIST,
-  WRAPPED_LIST,
-  SET_LIST,
-  ARBITRUM_LIST,
-  OPTIMISM_LIST,
-  CELO_LIST,
-  PLASMA_BNB_LIST,
-  AVALANCHE_LIST,
-  BASE_LIST,
-  ...UNSUPPORTED_LIST_URLS,
-]
+export const DEFAULT_ACTIVE_LIST_URLS: string[] = [HEMI_TESTNET_LIST]
+export const DEFAULT_INACTIVE_LIST_URLS: string[] = []
 
 export const DEFAULT_LIST_OF_LISTS: string[] = [...DEFAULT_ACTIVE_LIST_URLS, ...DEFAULT_INACTIVE_LIST_URLS]


### PR DESCRIPTION
This PR adds the url to fetch the token list for Hemi Testnet.
This will allow tokens to be properly listed and searched in the token selector dropdown. 
We'll also notice the tokens' icons get fetched as well now.

<img width="447" alt="Captura de pantalla 2024-05-06 a la(s) 16 49 55" src="https://github.com/hemilabs/interface/assets/1864435/baff3a49-efe1-4b02-a742-aaded942a8db">


Fixes https://github.com/hemilabs/interface/issues/5