### PR TITLE
Rename tokens

### DIFF
--- a/apps/web/craco.config.cjs
+++ b/apps/web/craco.config.cjs
@@ -92,7 +92,7 @@ module.exports = {
         maxRetries: 3,
       }),
       new NormalModuleReplacementPlugin(
-        /@uniswap\/(sdk-core|smart-order-router|universal-router-sdk)/,
+        /@uniswap\/(permit2-sdk|sdk-core|smart-order-router|universal-router-sdk)/,
         function(resource) {
           resource.request = resource.request.replace(/@uniswap/, '@hemilabs');
         }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -171,7 +171,7 @@
     "@graphql-codegen/typescript-operations": "^3.0.2",
     "@graphql-codegen/typescript-react-apollo": "^3.3.7",
     "@graphql-codegen/typescript-resolvers": "^3.2.1",
-    "@hemilabs/sdk-core": "4.2.0-beta.2",
+    "@hemilabs/sdk-core": "4.2.0-beta.5",
     "@hemilabs/smart-order-router": "3.26.1-beta.1",
     "@hemilabs/universal-router-sdk": "1.8.2-beta.3",
     "@juggle/resize-observer": "3.4.0",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -171,6 +171,7 @@
     "@graphql-codegen/typescript-operations": "^3.0.2",
     "@graphql-codegen/typescript-react-apollo": "^3.3.7",
     "@graphql-codegen/typescript-resolvers": "^3.2.1",
+    "@hemilabs/permit2-sdk": "1.2.0-beta.1",
     "@hemilabs/sdk-core": "4.2.0-beta.5",
     "@hemilabs/smart-order-router": "3.26.1-beta.1",
     "@hemilabs/universal-router-sdk": "1.8.2-beta.3",

--- a/apps/web/src/components/FiatOnrampModal/utils.ts
+++ b/apps/web/src/components/FiatOnrampModal/utils.ts
@@ -1,4 +1,4 @@
-import { ChainId, WETH9 } from '@uniswap/sdk-core'
+/*import { ChainId, WETH9 } from '@uniswap/sdk-core'
 import {
   MATIC_MAINNET,
   USDC_ARBITRUM,
@@ -8,7 +8,7 @@ import {
   USDT,
   WBTC,
   WETH_POLYGON,
-} from 'constants/tokens'
+} from 'constants/tokens'*/
 import { Chain } from 'graphql/data/__generated__/types-and-hooks'
 import { validateUrlChainParam } from 'graphql/data/util'
 
@@ -23,7 +23,7 @@ const CURRENCY_CODES: {
     native: MoonpaySupportedCurrencyCode
   }
 } = {
-  [Chain.Ethereum]: {
+  /*[Chain.Ethereum]: {
     [WETH9[ChainId.MAINNET]?.address.toLowerCase()]: 'weth',
     [USDC_MAINNET.address.toLowerCase()]: 'usdc',
     [USDT.address.toLowerCase()]: 'usdt',
@@ -43,7 +43,7 @@ const CURRENCY_CODES: {
     [USDC_POLYGON.address.toLowerCase()]: 'usdc_polygon',
     [WETH_POLYGON.address.toLowerCase()]: 'eth_polygon',
     native: 'matic_polygon',
-  },
+  },*/
 }
 
 export function getDefaultCurrencyCode(

--- a/apps/web/src/constants/lists.ts
+++ b/apps/web/src/constants/lists.ts
@@ -9,7 +9,7 @@ export const AVALANCHE_LIST =
   'https://raw.githubusercontent.com/ava-labs/avalanche-bridge-resources/main/token_list.json'
 export const BASE_LIST =
   'https://raw.githubusercontent.com/ethereum-optimism/ethereum-optimism.github.io/master/optimism.tokenlist.json'
-export const HEMI_TESTNET_LIST = 'https://raw.githubusercontent.com/hemilabs/interface/main/hemi-testnet.tokenlist.json'
+export const HEMI_TESTNET_LIST = 'https://raw.githubusercontent.com/hemilabs/token-list/master/src/hemi.tokenlist.json'
 
 export const UNSUPPORTED_LIST_URLS: string[] = []
 

--- a/apps/web/src/constants/routing.ts
+++ b/apps/web/src/constants/routing.ts
@@ -2,48 +2,7 @@
 import { ChainId, Currency, Token, WETH9 } from '@uniswap/sdk-core'
 
 import {
-  ARB,
-  BTC_BSC,
-  BUSD_BSC,
-  CEUR_CELO,
-  CEUR_CELO_ALFAJORES,
-  CUSD_CELO,
-  CUSD_CELO_ALFAJORES,
-  DAI,
-  DAI_ARBITRUM_ONE,
-  DAI_AVALANCHE,
-  DAI_BSC,
-  DAI_OPTIMISM,
-  DAI_POLYGON,
-  ETH_BSC,
-  OP,
-  PORTAL_ETH_CELO,
-  TESNET_DAI_HEMI_SEPOLIA,
-  USDC_ARBITRUM,
-  USDC_ARBITRUM_GOERLI,
-  USDC_AVALANCHE,
-  USDC_BASE,
-  USDC_BSC,
-  USDC_CELO,
-  USDC_MAINNET,
-  USDC_OPTIMISM,
-  USDC_OPTIMISM_GOERLI,
-  USDC_POLYGON,
-  USDC_POLYGON_MUMBAI,
-  USDT,
-  USDT_ARBITRUM_ONE,
-  USDT_AVALANCHE,
-  USDT_BSC,
-  USDT_OPTIMISM,
-  USDT_POLYGON,
-  WBTC,
-  WBTC_ARBITRUM_ONE,
-  WBTC_CELO,
-  WBTC_OPTIMISM,
-  WBTC_POLYGON,
-  WETH_AVALANCHE,
-  WETH_POLYGON,
-  WETH_POLYGON_MUMBAI,
+  DAI_HEMI_SEPOLIA,
   WRAPPED_NATIVE_CURRENCY,
   WETH_HEMI_SEPOLIA,
   nativeOnChain,
@@ -67,75 +26,9 @@ const WRAPPED_NATIVE_CURRENCIES_ONLY: ChainTokenList = Object.fromEntries(
  * Shows up in the currency select for swap and add liquidity
  */
 export const COMMON_BASES: ChainCurrencyList = {
-  [ChainId.MAINNET]: [
-    nativeOnChain(ChainId.MAINNET),
-    DAI,
-    USDC_MAINNET,
-    USDT,
-    WBTC,
-    WRAPPED_NATIVE_CURRENCY[ChainId.MAINNET] as Token,
-  ],
-  [ChainId.GOERLI]: [nativeOnChain(ChainId.GOERLI), WRAPPED_NATIVE_CURRENCY[ChainId.GOERLI] as Token],
-  [ChainId.SEPOLIA]: [nativeOnChain(ChainId.SEPOLIA), WRAPPED_NATIVE_CURRENCY[ChainId.SEPOLIA] as Token],
-
-  [ChainId.ARBITRUM_ONE]: [
-    nativeOnChain(ChainId.ARBITRUM_ONE),
-    ARB,
-    DAI_ARBITRUM_ONE,
-    USDC_ARBITRUM,
-    USDT_ARBITRUM_ONE,
-    WBTC_ARBITRUM_ONE,
-    WRAPPED_NATIVE_CURRENCY[ChainId.ARBITRUM_ONE] as Token,
-  ],
-  [ChainId.ARBITRUM_GOERLI]: [
-    nativeOnChain(ChainId.ARBITRUM_GOERLI),
-    WRAPPED_NATIVE_CURRENCY[ChainId.ARBITRUM_GOERLI] as Token,
-    USDC_ARBITRUM_GOERLI,
-  ],
-
-  [ChainId.OPTIMISM]: [
-    nativeOnChain(ChainId.OPTIMISM),
-    OP,
-    DAI_OPTIMISM,
-    USDC_OPTIMISM,
-    USDT_OPTIMISM,
-    WBTC_OPTIMISM,
-    WETH9[ChainId.OPTIMISM],
-  ],
-  [ChainId.OPTIMISM_GOERLI]: [nativeOnChain(ChainId.OPTIMISM_GOERLI), USDC_OPTIMISM_GOERLI],
-
-  [ChainId.BASE]: [nativeOnChain(ChainId.BASE), WRAPPED_NATIVE_CURRENCY[ChainId.BASE] as Token, USDC_BASE],
-
-  [ChainId.POLYGON]: [
-    nativeOnChain(ChainId.POLYGON),
-    WETH_POLYGON,
-    USDC_POLYGON,
-    DAI_POLYGON,
-    USDT_POLYGON,
-    WBTC_POLYGON,
-  ],
-  [ChainId.POLYGON_MUMBAI]: [
-    nativeOnChain(ChainId.POLYGON_MUMBAI),
-    WRAPPED_NATIVE_CURRENCY[ChainId.POLYGON_MUMBAI] as Token,
-    USDC_POLYGON_MUMBAI,
-    WETH_POLYGON_MUMBAI,
-  ],
-
-  [ChainId.CELO]: [nativeOnChain(ChainId.CELO), CEUR_CELO, CUSD_CELO, PORTAL_ETH_CELO, USDC_CELO, WBTC_CELO],
-  [ChainId.CELO_ALFAJORES]: [nativeOnChain(ChainId.CELO_ALFAJORES), CUSD_CELO_ALFAJORES, CEUR_CELO_ALFAJORES],
-
-  [ChainId.BNB]: [nativeOnChain(ChainId.BNB), DAI_BSC, USDC_BSC, USDT_BSC, ETH_BSC, BTC_BSC, BUSD_BSC],
-
-  [ChainId.AVALANCHE]: [
-    nativeOnChain(ChainId.AVALANCHE),
-    DAI_AVALANCHE,
-    USDC_AVALANCHE,
-    USDT_AVALANCHE,
-    WETH_AVALANCHE,
-  ],
   [ChainId.HEMI_SEPOLIA]: [
     nativeOnChain(ChainId.HEMI_SEPOLIA),
-    TESNET_DAI_HEMI_SEPOLIA,
+    DAI_HEMI_SEPOLIA,
     WETH_HEMI_SEPOLIA
   ]
 }
@@ -143,31 +36,12 @@ export const COMMON_BASES: ChainCurrencyList = {
 // used to construct the list of all pairs we consider by default in the frontend
 export const BASES_TO_TRACK_LIQUIDITY_FOR: ChainTokenList = {
   ...WRAPPED_NATIVE_CURRENCIES_ONLY,
-  [ChainId.MAINNET]: [...WRAPPED_NATIVE_CURRENCIES_ONLY[ChainId.MAINNET], DAI, USDC_MAINNET, USDT, WBTC],
-  [ChainId.BNB]: [
-    ...WRAPPED_NATIVE_CURRENCIES_ONLY[ChainId.BNB],
-    DAI_BSC,
-    USDC_BSC,
-    USDT_BSC,
-    BTC_BSC,
-    BUSD_BSC,
-    ETH_BSC,
-  ],
-  [ChainId.AVALANCHE]: [
-    ...WRAPPED_NATIVE_CURRENCIES_ONLY[ChainId.AVALANCHE],
-    DAI_AVALANCHE,
-    USDC_AVALANCHE,
-    USDT_AVALANCHE,
-    WETH_AVALANCHE,
+  [ChainId.HEMI_SEPOLIA]: [
+    ...WRAPPED_NATIVE_CURRENCIES_ONLY[ChainId.HEMI_SEPOLIA],
+    DAI_HEMI_SEPOLIA,
+    WETH_HEMI_SEPOLIA,
   ],
 }
 export const PINNED_PAIRS: { readonly [chainId: number]: [Token, Token][] } = {
-  [ChainId.MAINNET]: [
-    [
-      new Token(ChainId.MAINNET, '0x5d3a536E4D6DbD6114cc1Ead35777bAB948E3643', 8, 'cDAI', 'Compound Dai'),
-      new Token(ChainId.MAINNET, '0x39AA39c021dfbaE8faC545936693aC917d5E7563', 8, 'cUSDC', 'Compound USD Coin'),
-    ],
-    [USDC_MAINNET, USDT],
-    [DAI, USDT],
-  ],
+  [ChainId.HEMI_SEPOLIA]: [],
 }

--- a/apps/web/src/hooks/useAssetLogoSource.ts
+++ b/apps/web/src/hooks/useAssetLogoSource.ts
@@ -1,5 +1,5 @@
 import tokenLogoLookup from 'constants/tokenLogoLookup'
-import { isCelo, nativeOnChain } from 'constants/tokens'
+import { nativeOnChain } from 'constants/tokens'
 import { checkWarning, WARNING_LEVEL } from 'constants/tokenSafety'
 import { chainIdToNetworkName, getNativeLogoURI } from 'lib/hooks/useCurrencyLogoURIs'
 import uriToHttp from 'lib/utils/uriToHttp'
@@ -49,7 +49,7 @@ export function getInitialUrl(
   const networkName = chainId ? chainIdToNetworkName(chainId) : 'ethereum'
   const checksummedAddress = isAddress(address)
 
-  if (chainId && isCelo(chainId) && address === nativeOnChain(chainId).wrapped.address) {
+  if (chainId && address === nativeOnChain(chainId).wrapped.address) {
     return celoLogo
   }
 

--- a/apps/web/src/hooks/useStablecoinPrice.ts
+++ b/apps/web/src/hooks/useStablecoinPrice.ts
@@ -10,7 +10,7 @@ import {
   CUSD_CELO,
   CUSD_CELO_ALFAJORES,
   DAI_OPTIMISM,
-  TESNET_DAI_HEMI_SEPOLIA,
+  DAI_HEMI_SEPOLIA,
   USDC_ARBITRUM,
   USDC_ARBITRUM_GOERLI,
   USDC_AVALANCHE,
@@ -41,7 +41,7 @@ export const STABLECOIN_AMOUNT_OUT: { [key in SupportedInterfaceChain]: Currency
   [ChainId.ARBITRUM_GOERLI]: CurrencyAmount.fromRawAmount(USDC_ARBITRUM_GOERLI, 10_000e6),
   [ChainId.POLYGON_MUMBAI]: CurrencyAmount.fromRawAmount(USDC_POLYGON_MUMBAI, 10_000e6),
   [ChainId.CELO_ALFAJORES]: CurrencyAmount.fromRawAmount(CUSD_CELO_ALFAJORES, 10_000e6),
-  [ChainId.HEMI_SEPOLIA]: CurrencyAmount.fromRawAmount(TESNET_DAI_HEMI_SEPOLIA, 10_000e18),
+  [ChainId.HEMI_SEPOLIA]: CurrencyAmount.fromRawAmount(DAI_HEMI_SEPOLIA, 10_000e18),
 }
 
 /**

--- a/apps/web/src/pages/Swap/index.tsx
+++ b/apps/web/src/pages/Swap/index.tsx
@@ -44,7 +44,7 @@ export default function SwapPage({ className }: { className?: string }) {
 
   const { chainId: connectedChainId } = useWeb3React()
   const supportedChainId = asSupportedChain(connectedChainId)
-  const chainId = supportedChainId || ChainId.MAINNET
+  const chainId = supportedChainId || ChainId.HEMI_SEPOLIA
 
   const parsedQs = useParsedQueryString()
   const parsedCurrencyState = useMemo(() => {

--- a/apps/web/src/state/routing/utils.ts
+++ b/apps/web/src/state/routing/utils.ts
@@ -5,7 +5,7 @@ import { DutchOrderInfo, DutchOrderInfoJSON } from '@uniswap/uniswapx-sdk'
 import { Pair, Route as V2Route } from '@uniswap/v2-sdk'
 import { FeeAmount, Pool, Route as V3Route } from '@uniswap/v3-sdk'
 import { BIPS_BASE } from 'constants/misc'
-import { isAvalanche, isBsc, isPolygon, nativeOnChain, isHemiSepolia } from 'constants/tokens'
+import { nativeOnChain } from 'constants/tokens'
 import { toSlippagePercent } from 'utils/slippage'
 
 import { getApproveInfo, getWrapInfo } from './gas'
@@ -339,10 +339,6 @@ export function isExactInput(tradeType: TradeType): boolean {
 
 export function currencyAddressForSwapQuote(currency: Currency): string {
   if (currency.isNative) {
-    if (isPolygon(currency.chainId)) return SwapRouterNativeAssets.MATIC
-    if (isBsc(currency.chainId)) return SwapRouterNativeAssets.BNB
-    if (isAvalanche(currency.chainId)) return SwapRouterNativeAssets.AVAX
-    if (isHemiSepolia(currency.chainId)) return SwapRouterNativeAssets.thETH
     return SwapRouterNativeAssets.ETH
   }
 

--- a/apps/web/src/state/swap/SwapContext.tsx
+++ b/apps/web/src/state/swap/SwapContext.tsx
@@ -65,7 +65,7 @@ export const SwapAndLimitContext = createContext<SwapAndLimitContextType>({
     inputCurrency: undefined,
     outputCurrency: undefined,
   },
-  chainId: ChainId.MAINNET,
+  chainId: ChainId.HEMI_SEPOLIA,
   currentTab: SwapTab.Swap,
   setCurrentTab: () => undefined,
 })

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -32,6 +32,8 @@
     "paths": {
       "@uniswap/sdk-core": ["../../../node_modules/@hemilabs/sdk-core"],
       "@uniswap/sdk-core/*": ["../../../node_modules/@hemilabs/sdk-core/*"],
+      "@uniswap/permit2-sdk": ["../../../node_modules/@hemilabs/permit2-sdk"],
+      "@uniswap/permit2-sdk/*": ["../../../node_modules/@hemilabs/permit2-sdk/*"],
       "@uniswap/smart-order-router": ["../../../node_modules/@hemilabs/smart-order-router"],
       "@uniswap/smart-order-router/*": ["../../../node_modules/@hemilabs/smart-order-router/*"],
       "@uniswap/universal-router-sdk": ["../../../node_modules/@hemilabs/universal-router-sdk"],

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "immer": "9.0.21",
     "@uniswap/v2-sdk": "4.1.0",
     "@apollo/client": "3.9.6",
-    "@hemilabs/sdk-core": "4.2.0-beta.2",
+    "@hemilabs/sdk-core": "4.2.0-beta.5",
     "@react-navigation/routers": "6.1.9",
     "@react-navigation/core": "6.2.2",
     "@sideway/formula": "3.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5193,6 +5193,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@hemilabs/permit2-sdk@npm:1.2.0-beta.1":
+  version: 1.2.0-beta.1
+  resolution: "@hemilabs/permit2-sdk@npm:1.2.0-beta.1"
+  dependencies:
+    ethers: ^5.3.1
+    tiny-invariant: ^1.3.1
+  checksum: 49678f50dfce76dfea784674d67bf2d661e9c3050af4b7463ca14282832d0e6abb612640e11b2391684c4a99f91f91f378e21cd60da86d8de3bd307b963c0360
+  languageName: node
+  linkType: hard
+
 "@hemilabs/sdk-core@npm:4.2.0-beta.5":
   version: 4.2.0-beta.5
   resolution: "@hemilabs/sdk-core@npm:4.2.0-beta.5"
@@ -13531,6 +13541,7 @@ __metadata:
     "@graphql-codegen/typescript-operations": ^3.0.2
     "@graphql-codegen/typescript-react-apollo": ^3.3.7
     "@graphql-codegen/typescript-resolvers": ^3.2.1
+    "@hemilabs/permit2-sdk": 1.2.0-beta.1
     "@hemilabs/sdk-core": 4.2.0-beta.5
     "@hemilabs/smart-order-router": 3.26.1-beta.1
     "@hemilabs/universal-router-sdk": 1.8.2-beta.3

--- a/yarn.lock
+++ b/yarn.lock
@@ -5193,9 +5193,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hemilabs/sdk-core@npm:4.2.0-beta.2":
-  version: 4.2.0-beta.2
-  resolution: "@hemilabs/sdk-core@npm:4.2.0-beta.2"
+"@hemilabs/sdk-core@npm:4.2.0-beta.5":
+  version: 4.2.0-beta.5
+  resolution: "@hemilabs/sdk-core@npm:4.2.0-beta.5"
   dependencies:
     "@ethersproject/address": ^5.0.2
     "@ethersproject/bignumber": ^5.7.0
@@ -5204,7 +5204,7 @@ __metadata:
     jsbi: ^3.1.4
     tiny-invariant: ^1.1.0
     toformat: ^2.0.0
-  checksum: 9f69b0898aa9c97a905fb20022bd2f8de3b8cb4d7ad5818d2cef97a9ce913dfe2874fe9967a3362a6ee23cb3844674ab8ce2f3efedc801ee43362582e6ca8e3a
+  checksum: 49d1a78f63928752cf78c661f501e541c6d38b8eb2e4787d97b1cb70615442eff3f372960cb544636a9ad36ae43b714157ba8336709d475b280fa4babf4dee54
   languageName: node
   linkType: hard
 
@@ -13531,7 +13531,7 @@ __metadata:
     "@graphql-codegen/typescript-operations": ^3.0.2
     "@graphql-codegen/typescript-react-apollo": ^3.3.7
     "@graphql-codegen/typescript-resolvers": ^3.2.1
-    "@hemilabs/sdk-core": 4.2.0-beta.2
+    "@hemilabs/sdk-core": 4.2.0-beta.5
     "@hemilabs/smart-order-router": 3.26.1-beta.1
     "@hemilabs/universal-router-sdk": 1.8.2-beta.3
     "@juggle/resize-observer": 3.4.0


### PR DESCRIPTION
In this PR:

- Removes many references to unsupported chains
- Renames tokens from thDAI->DAI and thETH->ETH
- Makes HEMI_SEPOLIA the default chain. It will now prompt to "Connect to HEMI_SEPOLIA" if connected to any other unsupported chain, and won't show any token from those chains.
- Fixes an issue with allowance that prevented swapping from ERC-20 tokens (eg.: DAI->ETH)

## Screenshots
"Connect to Hemi Sepolia":

https://github.com/hemilabs/interface/assets/1864435/e0f35bc9-17ea-46d8-b843-14d9112816d0



A successful swap from DAI->ETH:

https://github.com/hemilabs/interface/assets/1864435/cb26db03-0486-40a3-90c1-f7f65c9ea305



Fixes #14
