### PR TITLE
Add USDC.e and USDT.e support

### DIFF
--- a/apps/web/src/components/PositionListItem/index.tsx
+++ b/apps/web/src/components/PositionListItem/index.tsx
@@ -19,7 +19,7 @@ import { HideSmall, SmallOnly, ThemedText } from 'theme/components'
 import { useFormatter } from 'utils/formatNumbers'
 import { unwrappedToken } from 'utils/unwrappedToken'
 
-import { DAI, USDC_MAINNET, USDT, WBTC, WRAPPED_NATIVE_CURRENCY } from '../../constants/tokens'
+import { DAI_HEMI_SEPOLIA, USDC_HEMI_SEPOLIA, USDT_HEMI_SEPOLIA, WRAPPED_NATIVE_CURRENCY } from '../../constants/tokens'
 
 const LinkRow = styled(Link)`
   align-items: center;
@@ -124,7 +124,7 @@ export function getPriceOrderingFromPositionForUI(position?: Position): {
   const token1 = position.amount1.currency
 
   // if token0 is a dollar-stable asset, set it as the quote token
-  const stables = [DAI, USDC_MAINNET, USDT]
+  const stables = [DAI_HEMI_SEPOLIA, USDC_HEMI_SEPOLIA, USDT_HEMI_SEPOLIA]
   if (stables.some((stable) => stable.equals(token0))) {
     return {
       priceLower: position.token0PriceUpper.invert(),
@@ -135,7 +135,7 @@ export function getPriceOrderingFromPositionForUI(position?: Position): {
   }
 
   // if token1 is an ETH-/BTC-stable asset, set it as the base token
-  const bases = [...Object.values(WRAPPED_NATIVE_CURRENCY), WBTC]
+  const bases = [...Object.values(WRAPPED_NATIVE_CURRENCY)]
   if (bases.some((base) => base && base.equals(token1))) {
     return {
       priceLower: position.token0PriceUpper.invert(),

--- a/apps/web/src/components/swap/constants.ts
+++ b/apps/web/src/components/swap/constants.ts
@@ -1,8 +1,6 @@
-import { LDO, MNW, NMR, USDT as USDT_MAINNET } from 'constants/tokens'
-
 // List of tokens that require existing allowance to be reset before approving the new amount (mainnet only).
 // See the `approve` function here: https://etherscan.io/address/0xdAC17F958D2ee523a2206206994597C13D831ec7#code
-export const RESET_APPROVAL_TOKENS = [USDT_MAINNET, LDO, NMR, MNW]
+export const RESET_APPROVAL_TOKENS = []
 
 export enum SwapTab {
   Swap = '',

--- a/apps/web/src/constants/chainInfo.ts
+++ b/apps/web/src/constants/chainInfo.ts
@@ -8,7 +8,7 @@ import {
   AVALANCHE_LIST,
   BASE_LIST,
   CELO_LIST,
-  HEMI_TESTNET_LIST,
+  HEMI_LIST,
   OPTIMISM_LIST,
   PLASMA_BNB_LIST,
 } from './lists'
@@ -256,7 +256,7 @@ const CHAIN_INFO: ChainInfoMap = {
     networkType: NetworkType.L2,
     blockWaitMsBeforeWarning: ms(`25m`),
     bridge: 'http://app.hemi.xyz',
-    defaultListUrl: HEMI_TESTNET_LIST,
+    defaultListUrl: HEMI_LIST,
     docs: 'https://docs.hemi.xyz',
     explorer: 'https://testnet.explorer.hemi.xyz',
     infoLink: 'https://docs.hemi.xyz/',

--- a/apps/web/src/constants/lists.ts
+++ b/apps/web/src/constants/lists.ts
@@ -9,12 +9,12 @@ export const AVALANCHE_LIST =
   'https://raw.githubusercontent.com/ava-labs/avalanche-bridge-resources/main/token_list.json'
 export const BASE_LIST =
   'https://raw.githubusercontent.com/ethereum-optimism/ethereum-optimism.github.io/master/optimism.tokenlist.json'
-export const HEMI_TESTNET_LIST = 'https://raw.githubusercontent.com/hemilabs/token-list/master/src/hemi.tokenlist.json'
+export const HEMI_LIST = 'https://raw.githubusercontent.com/hemilabs/token-list/master/src/hemi.tokenlist.json'
 
 export const UNSUPPORTED_LIST_URLS: string[] = []
 
 // default lists to be 'active' aka searched across
-export const DEFAULT_ACTIVE_LIST_URLS: string[] = [HEMI_TESTNET_LIST]
+export const DEFAULT_ACTIVE_LIST_URLS: string[] = [HEMI_LIST]
 export const DEFAULT_INACTIVE_LIST_URLS: string[] = []
 
 export const DEFAULT_LIST_OF_LISTS: string[] = [...DEFAULT_ACTIVE_LIST_URLS, ...DEFAULT_INACTIVE_LIST_URLS]

--- a/apps/web/src/constants/routing.ts
+++ b/apps/web/src/constants/routing.ts
@@ -5,7 +5,7 @@ import {
   DAI_HEMI_SEPOLIA,
   WRAPPED_NATIVE_CURRENCY,
   WETH_HEMI_SEPOLIA,
-  nativeOnChain,
+  nativeOnChain, USDT_HEMI_SEPOLIA, USDC_HEMI_SEPOLIA,
 } from './tokens'
 
 type ChainTokenList = {

--- a/apps/web/src/constants/tokens.ts
+++ b/apps/web/src/constants/tokens.ts
@@ -4,255 +4,21 @@ import invariant from 'tiny-invariant'
 // eslint-disable-next-line no-restricted-syntax
 export const NATIVE_CHAIN_ID = 'NATIVE'
 
-export const USDC_MAINNET = new Token(
-  ChainId.MAINNET,
-  '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
-  6,
-  'USDC',
-  'USD//C'
-)
-export const USDC_GOERLI = new Token(ChainId.GOERLI, '0x07865c6e87b9f70255377e024ace6630c1eaa37f', 6, 'USDC', 'USD//C')
-export const USDC_SEPOLIA = new Token(
-  ChainId.SEPOLIA,
-  '0x6f14C02Fc1F78322cFd7d707aB90f18baD3B54f5',
-  6,
-  'USDC',
-  'USD//C'
-)
-export const USDC_OPTIMISM = new Token(
-  ChainId.OPTIMISM,
-  '0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85',
-  6,
-  'USDC',
-  'USD//C'
-)
-export const USDC_OPTIMISM_GOERLI = new Token(
-  ChainId.OPTIMISM_GOERLI,
-  '0xe05606174bac4A6364B31bd0eCA4bf4dD368f8C6',
-  6,
-  'USDC',
-  'USD//C'
-)
-export const USDC_ARBITRUM = new Token(
-  ChainId.ARBITRUM_ONE,
-  '0xaf88d065e77c8cC2239327C5EDb3A432268e5831',
-  6,
-  'USDC',
-  'USD//C'
-)
-export const USDC_ARBITRUM_GOERLI = new Token(
-  ChainId.ARBITRUM_GOERLI,
-  '0x8FB1E3fC51F3b789dED7557E680551d93Ea9d892',
-  6,
-  'USDC',
-  'USD//C'
-)
-export const USDC_POLYGON = new Token(
-  ChainId.POLYGON,
-  '0x3c499c542cef5e3811e1192ce70d8cc03d5c3359',
-  6,
-  'USDC',
-  'USD Coin'
-)
-export const USDC_POLYGON_MUMBAI = new Token(
-  ChainId.POLYGON_MUMBAI,
-  '0x0fa8781a83e46826621b3bc094ea2a0212e71b23',
-  6,
-  'USDC',
-  'USD Coin'
-)
-export const USDC_CELO = new Token(ChainId.CELO, '0xceba9300f2b948710d2653dd7b07f33a8b32118c', 6, 'USDC', 'USD Coin')
-export const USDC_BASE = new Token(ChainId.BASE, '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913', 6, 'USDC', 'USD Coin')
-
-export const DAI = new Token(ChainId.MAINNET, '0x6B175474E89094C44Da98b954EedeAC495271d0F', 18, 'DAI', 'Dai Stablecoin')
-export const DAI_ARBITRUM_ONE = new Token(
-  ChainId.ARBITRUM_ONE,
-  '0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1',
-  18,
-  'DAI',
-  'Dai stable coin'
-)
-export const DAI_OPTIMISM = new Token(
-  ChainId.OPTIMISM,
-  '0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1',
-  18,
-  'DAI',
-  'Dai stable coin'
-)
-export const MATIC_MAINNET = new Token(
-  ChainId.MAINNET,
-  '0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0',
-  18,
-  'MATIC',
-  'Polygon Matic'
-)
-export const MATIC_POLYGON = new Token(
-  ChainId.POLYGON,
-  '0x0000000000000000000000000000000000001010',
-  18,
-  'MATIC',
-  'Matic'
-)
-export const DAI_POLYGON = new Token(
-  ChainId.POLYGON,
-  '0x8f3Cf7ad23Cd3CaDbD9735AFf958023239c6A063',
-  18,
-  'DAI',
-  'Dai Stablecoin'
-)
-
-export const USDT_POLYGON = new Token(
-  ChainId.POLYGON,
-  '0xc2132d05d31c914a87c6611c10748aeb04b58e8f',
-  6,
-  'USDT',
-  'Tether USD'
-)
-export const WBTC_POLYGON = new Token(
-  ChainId.POLYGON,
-  '0x1bfd67037b42cf73acf2047067bd4f2c47d9bfd6',
-  8,
-  'WBTC',
-  'Wrapped BTC'
-)
-export const USDT = new Token(ChainId.MAINNET, '0xdAC17F958D2ee523a2206206994597C13D831ec7', 6, 'USDT', 'Tether USD')
-export const USDT_ARBITRUM_ONE = new Token(
-  ChainId.ARBITRUM_ONE,
-  '0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9',
-  6,
-  'USDT',
-  'Tether USD'
-)
-export const USDT_OPTIMISM = new Token(
-  ChainId.OPTIMISM,
-  '0x94b008aA00579c1307B0EF2c499aD98a8ce58e58',
-  6,
-  'USDT',
-  'Tether USD'
-)
-export const WBTC = new Token(ChainId.MAINNET, '0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599', 8, 'WBTC', 'Wrapped BTC')
-export const WBTC_ARBITRUM_ONE = new Token(
-  ChainId.ARBITRUM_ONE,
-  '0x2f2a2543B76A4166549F7aaB2e75Bef0aefC5B0f',
-  8,
-  'WBTC',
-  'Wrapped BTC'
-)
-export const WBTC_OPTIMISM = new Token(
-  ChainId.OPTIMISM,
-  '0x68f180fcCe6836688e9084f035309E29Bf0A2095',
-  8,
-  'WBTC',
-  'Wrapped BTC'
-)
-export const WETH_POLYGON_MUMBAI = new Token(
-  ChainId.POLYGON_MUMBAI,
-  '0xa6fa4fb5f76172d178d61b04b0ecd319c5d1c0aa',
-  18,
-  'WETH',
-  'Wrapped Ether'
-)
-
-export const WETH_POLYGON = new Token(
-  ChainId.POLYGON,
-  '0x7ceb23fd6bc0add59e62ac25578270cff1b9f619',
-  18,
-  'WETH',
-  'Wrapped Ether'
-)
-const CELO_CELO = new Token(ChainId.CELO, '0x471EcE3750Da237f93B8E339c536989b8978a438', 18, 'CELO', 'Celo')
-export const CUSD_CELO = new Token(
-  ChainId.CELO,
-  '0x765DE816845861e75A25fCA122bb6898B8B1282a',
-  18,
-  'cUSD',
-  'Celo Dollar'
-)
-export const CEUR_CELO = new Token(
-  ChainId.CELO,
-  '0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73',
-  18,
-  'cEUR',
-  'Celo Euro Stablecoin'
-)
-export const PORTAL_ETH_CELO = new Token(
-  ChainId.CELO,
-  '0x66803FB87aBd4aaC3cbB3fAd7C3aa01f6F3FB207',
-  18,
-  'ETH',
-  'Portal Ether'
-)
-export const WBTC_CELO = new Token(
-  ChainId.CELO,
-  '0xd71Ffd0940c920786eC4DbB5A12306669b5b81EF',
-  18,
-  'WBTC',
-  'Wrapped BTC'
-)
-const CELO_CELO_ALFAJORES = new Token(
-  ChainId.CELO_ALFAJORES,
-  '0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9',
-  18,
-  'CELO',
-  'Celo'
-)
-export const CUSD_CELO_ALFAJORES = new Token(
-  ChainId.CELO_ALFAJORES,
-  '0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1',
-  18,
-  'CUSD',
-  'Celo Dollar'
-)
-export const CEUR_CELO_ALFAJORES = new Token(
-  ChainId.CELO_ALFAJORES,
-  '0x10c892A6EC43a53E45D0B916B4b7D383B1b78C0F',
-  18,
-  'CEUR',
-  'Celo Euro Stablecoin'
-)
-
-export const USDC_BSC = new Token(ChainId.BNB, '0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d', 18, 'USDC', 'USDC')
-export const USDT_BSC = new Token(ChainId.BNB, '0x55d398326f99059fF775485246999027B3197955', 18, 'USDT', 'USDT')
-export const ETH_BSC = new Token(ChainId.BNB, '0x2170Ed0880ac9A755fd29B2688956BD959F933F8', 18, 'ETH', 'Ethereum')
-export const BTC_BSC = new Token(ChainId.BNB, '0x7130d2A12B9BCbFAe4f2634d864A1Ee1Ce3Ead9c', 18, 'BTCB', 'BTCB')
-export const BUSD_BSC = new Token(ChainId.BNB, '0xe9e7CEA3DedcA5984780Bafc599bD69ADd087D56', 18, 'BUSD', 'BUSD')
-export const DAI_BSC = new Token(ChainId.BNB, '0x1AF3F329e8BE154074D8769D1FFa4eE058B1DBc3', 18, 'DAI', 'DAI')
-
-export const USDC_AVALANCHE = new Token(
-  ChainId.AVALANCHE,
-  '0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E',
-  6,
-  'USDC',
-  'USDC Token'
-)
-export const USDT_AVALANCHE = new Token(
-  ChainId.AVALANCHE,
-  '0x9702230A8Ea53601f5cD2dc00fDBc13d4dF4A8c7',
-  6,
-  'USDT',
-  'Tether USD'
-)
-export const WETH_AVALANCHE = new Token(
-  ChainId.AVALANCHE,
-  '0x49D5c2BdFfac6CE2BFdB6640F4F80f226bc10bAB',
-  18,
-  'WETH',
-  'Wrapped Ether'
-)
-export const DAI_AVALANCHE = new Token(
-  ChainId.AVALANCHE,
-  '0xd586E7F844cEa2F87f50152665BCbc2C279D8d70',
-  18,
-  'DAI.e',
-  'Dai.e Token'
-)
-
 export const DAI_HEMI_SEPOLIA = new Token(
   ChainId.HEMI_SEPOLIA,
   '0xec46e0efb2ea8152da0327a5eb3ff9a43956f13e',
   18,
   'DAI',
   'Testnet Hemi DAI'
+)
+
+
+export const USDC_HEMI_SEPOLIA = new Token(
+  ChainId.HEMI_SEPOLIA,
+  '0xD47971C7F5B1067d25cd45d30b2c9eb60de96443',
+  6,
+  'USDC.e',
+  'USD Coin'
 )
 
 export const USDT_HEMI_SEPOLIA = new Token(
@@ -277,179 +43,13 @@ export const UNI: { [chainId: number]: Token } = {
   [ChainId.SEPOLIA]: new Token(ChainId.SEPOLIA, UNI_ADDRESSES[ChainId.SEPOLIA], 18, 'UNI', 'Uniswap'),
 }
 
-export const ARB = new Token(ChainId.ARBITRUM_ONE, '0x912CE59144191C1204E64559FE8253a0e49E6548', 18, 'ARB', 'Arbitrum')
-
-export const OP = new Token(ChainId.OPTIMISM, '0x4200000000000000000000000000000000000042', 18, 'OP', 'Optimism')
-
-export const LDO = new Token(ChainId.MAINNET, '0x5A98FcBEA516Cf06857215779Fd812CA3beF1B32', 18, 'LDO', 'Lido DAO Token')
-export const NMR = new Token(ChainId.MAINNET, '0x1776e1F26f98b1A5dF9cD347953a26dd3Cb46671', 18, 'NMR', 'Numeraire')
-export const MNW = new Token(
-  ChainId.MAINNET,
-  '0xd3E4Ba569045546D09CF021ECC5dFe42b1d7f6E4',
-  18,
-  'MNW',
-  'Morpheus.Network'
-)
-
 export const WRAPPED_NATIVE_CURRENCY: { [chainId: number]: Token | undefined } = {
   ...(WETH9 as Record<ChainId, Token>),
-  [ChainId.OPTIMISM]: new Token(
-    ChainId.OPTIMISM,
-    '0x4200000000000000000000000000000000000006',
-    18,
-    'WETH',
-    'Wrapped Ether'
-  ),
-  [ChainId.OPTIMISM_GOERLI]: new Token(
-    ChainId.OPTIMISM_GOERLI,
-    '0x4200000000000000000000000000000000000006',
-    18,
-    'WETH',
-    'Wrapped Ether'
-  ),
-  [ChainId.BASE]: new Token(ChainId.BASE, '0x4200000000000000000000000000000000000006', 18, 'WETH', 'Wrapped Ether'),
-  [ChainId.ARBITRUM_ONE]: new Token(
-    ChainId.ARBITRUM_ONE,
-    '0x82aF49447D8a07e3bd95BD0d56f35241523fBab1',
-    18,
-    'WETH',
-    'Wrapped Ether'
-  ),
-  [ChainId.ARBITRUM_GOERLI]: new Token(
-    ChainId.ARBITRUM_GOERLI,
-    '0xe39Ab88f8A4777030A534146A9Ca3B52bd5D43A3',
-    18,
-    'WETH',
-    'Wrapped Ether'
-  ),
-  [ChainId.SEPOLIA]: new Token(
-    ChainId.SEPOLIA,
-    '0xfFf9976782d46CC05630D1f6eBAb18b2324d6B14',
-    18,
-    'WETH',
-    'Wrapped Ether'
-  ),
-  [ChainId.POLYGON]: new Token(
-    ChainId.POLYGON,
-    '0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270',
-    18,
-    'WMATIC',
-    'Wrapped MATIC'
-  ),
-  [ChainId.POLYGON_MUMBAI]: new Token(
-    ChainId.POLYGON_MUMBAI,
-    '0x9c3C9283D3e44854697Cd22D3Faa240Cfb032889',
-    18,
-    'WMATIC',
-    'Wrapped MATIC'
-  ),
-  [ChainId.CELO]: new Token(
-    ChainId.CELO,
-    '0x471ece3750da237f93b8e339c536989b8978a438',
-    18,
-    'CELO',
-    'Celo native asset'
-  ),
-  [ChainId.CELO_ALFAJORES]: new Token(
-    ChainId.CELO_ALFAJORES,
-    '0xf194afdf50b03e69bd7d057c1aa9e10c9954e4c9',
-    18,
-    'CELO',
-    'Celo native asset'
-  ),
-  [ChainId.BNB]: new Token(ChainId.BNB, '0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c', 18, 'WBNB', 'Wrapped BNB'),
-  [ChainId.AVALANCHE]: new Token(
-    ChainId.AVALANCHE,
-    '0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7',
-    18,
-    'WAVAX',
-    'Wrapped AVAX'
-  ),
   [ChainId.HEMI_SEPOLIA]: WETH_HEMI_SEPOLIA
 }
 
-export function isCelo(chainId: number): chainId is ChainId.CELO | ChainId.CELO_ALFAJORES {
-  return chainId === ChainId.CELO_ALFAJORES || chainId === ChainId.CELO
-}
 
-function getCeloNativeCurrency(chainId: number) {
-  switch (chainId) {
-    case ChainId.CELO_ALFAJORES:
-      return CELO_CELO_ALFAJORES
-    case ChainId.CELO:
-      return CELO_CELO
-    default:
-      throw new Error('Not celo')
-  }
-}
-
-export function isPolygon(chainId: number): chainId is ChainId.POLYGON | ChainId.POLYGON_MUMBAI {
-  return chainId === ChainId.POLYGON_MUMBAI || chainId === ChainId.POLYGON
-}
-
-class PolygonNativeCurrency extends NativeCurrency {
-  equals(other: Currency): boolean {
-    return other.isNative && other.chainId === this.chainId
-  }
-
-  get wrapped(): Token {
-    if (!isPolygon(this.chainId)) throw new Error('Not Polygon')
-    const wrapped = WRAPPED_NATIVE_CURRENCY[this.chainId]
-    invariant(wrapped instanceof Token)
-    return wrapped
-  }
-
-  public constructor(chainId: number) {
-    if (!isPolygon(chainId)) throw new Error('Not Polygon')
-    super(chainId, 18, 'MATIC', 'Matic')
-  }
-}
-
-export function isBsc(chainId: number): chainId is ChainId.BNB {
-  return chainId === ChainId.BNB
-}
-
-class BscNativeCurrency extends NativeCurrency {
-  equals(other: Currency): boolean {
-    return other.isNative && other.chainId === this.chainId
-  }
-
-  get wrapped(): Token {
-    if (!isBsc(this.chainId)) throw new Error('Not bnb')
-    const wrapped = WRAPPED_NATIVE_CURRENCY[this.chainId]
-    invariant(wrapped instanceof Token)
-    return wrapped
-  }
-
-  public constructor(chainId: number) {
-    if (!isBsc(chainId)) throw new Error('Not bnb')
-    super(chainId, 18, 'BNB', 'BNB')
-  }
-}
-
-export function isAvalanche(chainId: number): chainId is ChainId.AVALANCHE {
-  return chainId === ChainId.AVALANCHE
-}
-
-class AvaxNativeCurrency extends NativeCurrency {
-  equals(other: Currency): boolean {
-    return other.isNative && other.chainId === this.chainId
-  }
-
-  get wrapped(): Token {
-    if (!isAvalanche(this.chainId)) throw new Error('Not avalanche')
-    const wrapped = WRAPPED_NATIVE_CURRENCY[this.chainId]
-    invariant(wrapped instanceof Token)
-    return wrapped
-  }
-
-  public constructor(chainId: number) {
-    if (!isAvalanche(chainId)) throw new Error('Not avalanche')
-    super(chainId, 18, 'AVAX', 'AVAX')
-  }
-}
-
-export function isHemi(chainId: number): chainId is ChainId.HEMI {
+/*export function isHemi(chainId: number): chainId is ChainId.HEMI {
   return chainId === ChainId.HEMI
 }
 
@@ -469,7 +69,7 @@ class HemiNativeCurrency extends NativeCurrency {
     if (!isHemi(chainId)) throw new Error('Not Hemi')
     super(chainId, 18, 'ETH', 'ETH')
   }
-}
+}*/
 export function isHemiSepolia(chainId: number): chainId is ChainId.HEMI_SEPOLIA {
   return chainId === ChainId.HEMI_SEPOLIA
 }
@@ -519,17 +119,9 @@ export function nativeOnChain(chainId: number): NativeCurrency | Token {
   if (cachedNativeCurrency[chainId]) return cachedNativeCurrency[chainId]
   let nativeCurrency: NativeCurrency | Token
 
-  if (isPolygon(chainId)) {
-    nativeCurrency = new PolygonNativeCurrency(chainId)
-  } else if (isCelo(chainId)) {
-    nativeCurrency = getCeloNativeCurrency(chainId)
-  } else if (isBsc(chainId)) {
-    nativeCurrency = new BscNativeCurrency(chainId)
-  } else if (isAvalanche(chainId)) {
-    nativeCurrency = new AvaxNativeCurrency(chainId)
-  } else if (isHemi(chainId)) {
+  /*if (isHemi(chainId)) {
     nativeCurrency = new HemiNativeCurrency(chainId)
-  } else if (isHemiSepolia(chainId)) {
+  } else */if (isHemiSepolia(chainId)) {
     nativeCurrency = new HemiSepoliaNativeCurrency(chainId)
   } else {
     nativeCurrency = ExtendedEther.onChain(chainId)
@@ -539,20 +131,7 @@ export function nativeOnChain(chainId: number): NativeCurrency | Token {
 
 export const TOKEN_SHORTHANDS: { [shorthand: string]: { [chainId in ChainId]?: string } } = {
   USDC: {
-    [ChainId.MAINNET]: USDC_MAINNET.address,
-    [ChainId.ARBITRUM_ONE]: USDC_ARBITRUM.address,
-    [ChainId.ARBITRUM_GOERLI]: USDC_ARBITRUM_GOERLI.address,
-    [ChainId.OPTIMISM]: USDC_OPTIMISM.address,
-    [ChainId.OPTIMISM_GOERLI]: USDC_OPTIMISM_GOERLI.address,
-    [ChainId.POLYGON]: USDC_POLYGON.address,
-    [ChainId.POLYGON_MUMBAI]: USDC_POLYGON_MUMBAI.address,
-    [ChainId.BNB]: USDC_BSC.address,
-    [ChainId.BASE]: USDC_BASE.address,
-    [ChainId.CELO]: USDC_CELO.address,
-    [ChainId.CELO_ALFAJORES]: USDC_CELO.address,
-    [ChainId.GOERLI]: USDC_GOERLI.address,
-    [ChainId.SEPOLIA]: USDC_SEPOLIA.address,
-    [ChainId.AVALANCHE]: USDC_AVALANCHE.address,
+    [ChainId.HEMI_SEPOLIA]: USDC_HEMI_SEPOLIA.address,
   },
   USDT: {
     [ChainId.HEMI_SEPOLIA]: USDT_HEMI_SEPOLIA.address,
@@ -560,25 +139,29 @@ export const TOKEN_SHORTHANDS: { [shorthand: string]: { [chainId in ChainId]?: s
 }
 
 const STABLECOINS: { [chainId in ChainId]: Token[] } = {
-  [ChainId.MAINNET]: [USDC_MAINNET, DAI, USDT],
-  [ChainId.ARBITRUM_ONE]: [USDC_ARBITRUM, DAI_ARBITRUM_ONE],
-  [ChainId.ARBITRUM_GOERLI]: [USDC_ARBITRUM_GOERLI],
-  [ChainId.OPTIMISM]: [USDC_OPTIMISM, DAI_OPTIMISM],
-  [ChainId.OPTIMISM_GOERLI]: [USDC_OPTIMISM_GOERLI],
-  [ChainId.POLYGON]: [USDC_POLYGON, DAI_POLYGON],
-  [ChainId.POLYGON_MUMBAI]: [USDC_POLYGON_MUMBAI],
-  [ChainId.BNB]: [USDC_BSC],
-  [ChainId.BASE]: [USDC_BASE],
-  [ChainId.CELO]: [USDC_CELO],
-  [ChainId.CELO_ALFAJORES]: [USDC_CELO],
-  [ChainId.GOERLI]: [USDC_GOERLI],
-  [ChainId.SEPOLIA]: [USDC_SEPOLIA],
-  [ChainId.AVALANCHE]: [USDC_AVALANCHE],
+  [ChainId.MAINNET]: [],
+  [ChainId.ARBITRUM_ONE]: [],
+  [ChainId.ARBITRUM_GOERLI]: [],
+  [ChainId.OPTIMISM]: [],
+  [ChainId.OPTIMISM_GOERLI]: [],
+  [ChainId.POLYGON]: [],
+  [ChainId.POLYGON_MUMBAI]: [],
+  [ChainId.BNB]: [],
+  [ChainId.BASE]: [],
+  [ChainId.CELO]: [],
+  [ChainId.CELO_ALFAJORES]: [],
+  [ChainId.GOERLI]: [],
+  [ChainId.SEPOLIA]: [],
+  [ChainId.AVALANCHE]: [],
   [ChainId.GNOSIS]: [],
   [ChainId.MOONBEAM]: [],
   [ChainId.BASE_GOERLI]: [],
-  [ChainId.OPTIMISM_SEPOLIA]: [USDC_SEPOLIA],
+  [ChainId.OPTIMISM_SEPOLIA]: [],
   [ChainId.ARBITRUM_SEPOLIA]: [],
+  [ChainId.ZORA]: [],
+  [ChainId.ZORA_SEPOLIA]: [],
+  [ChainId.ROOTSTOCK]: [],
+  [ChainId.BLAST]: [],
   [ChainId.HEMI_SEPOLIA]: [DAI_HEMI_SEPOLIA, USDT_HEMI_SEPOLIA],
 }
 

--- a/apps/web/src/hooks/useERC20Permit.ts
+++ b/apps/web/src/hooks/useERC20Permit.ts
@@ -6,7 +6,6 @@ import JSBI from 'jsbi'
 import { useSingleCallResult } from 'lib/hooks/multicall'
 import { useMemo, useState } from 'react'
 
-import { DAI, UNI, USDC_MAINNET } from '../constants/tokens'
 import { useEIP2612Contract } from './useContract'
 import useIsArgentWallet from './useIsArgentWallet'
 
@@ -31,17 +30,9 @@ const PERMITTABLE_TOKENS: {
     [checksummedTokenAddress: string]: PermitInfo
   }
 } = {
-  [ChainId.MAINNET]: {
-    [USDC_MAINNET.address]: { type: PermitType.AMOUNT, name: 'USD Coin', version: '2' },
-    [DAI.address]: { type: PermitType.ALLOWED, name: 'Dai Stablecoin', version: '1' },
-    [UNI[ChainId.MAINNET].address]: { type: PermitType.AMOUNT, name: 'Uniswap' },
-  },
-  [ChainId.GOERLI]: {
-    [UNI[ChainId.GOERLI].address]: { type: PermitType.AMOUNT, name: 'Uniswap' },
-  },
-  [ChainId.SEPOLIA]: {
-    [UNI[ChainId.SEPOLIA].address]: { type: PermitType.AMOUNT, name: 'Uniswap' },
-  },
+  [ChainId.MAINNET]: {},
+  [ChainId.GOERLI]: {},
+  [ChainId.SEPOLIA]: {},
 }
 
 enum UseERC20PermitState {

--- a/apps/web/src/hooks/useStablecoinPrice.ts
+++ b/apps/web/src/hooks/useStablecoinPrice.ts
@@ -7,40 +7,12 @@ import { useRoutingAPITrade } from 'state/routing/useRoutingAPITrade'
 
 import { SupportedInterfaceChain, asSupportedChain } from 'constants/chains'
 import {
-  CUSD_CELO,
-  CUSD_CELO_ALFAJORES,
-  DAI_OPTIMISM,
   DAI_HEMI_SEPOLIA,
-  USDC_ARBITRUM,
-  USDC_ARBITRUM_GOERLI,
-  USDC_AVALANCHE,
-  USDC_BASE,
-  USDC_GOERLI,
-  USDC_MAINNET,
-  USDC_OPTIMISM_GOERLI,
-  USDC_POLYGON,
-  USDC_POLYGON_MUMBAI,
-  USDC_SEPOLIA,
-  USDT_BSC,
 } from '../constants/tokens'
 
 // Stablecoin amounts used when calculating spot price for a given currency.
 // The amount is large enough to filter low liquidity pairs.
 export const STABLECOIN_AMOUNT_OUT: { [key in SupportedInterfaceChain]: CurrencyAmount<Token> } = {
-  [ChainId.MAINNET]: CurrencyAmount.fromRawAmount(USDC_MAINNET, 100_000e6),
-  [ChainId.ARBITRUM_ONE]: CurrencyAmount.fromRawAmount(USDC_ARBITRUM, 10_000e6),
-  [ChainId.OPTIMISM]: CurrencyAmount.fromRawAmount(DAI_OPTIMISM, 10_000e18),
-  [ChainId.POLYGON]: CurrencyAmount.fromRawAmount(USDC_POLYGON, 10_000e6),
-  [ChainId.CELO]: CurrencyAmount.fromRawAmount(CUSD_CELO, 10_000e18),
-  [ChainId.BNB]: CurrencyAmount.fromRawAmount(USDT_BSC, 100e18),
-  [ChainId.AVALANCHE]: CurrencyAmount.fromRawAmount(USDC_AVALANCHE, 10_000e6),
-  [ChainId.BASE]: CurrencyAmount.fromRawAmount(USDC_BASE, 10_000e6),
-  [ChainId.GOERLI]: CurrencyAmount.fromRawAmount(USDC_GOERLI, 10_000e6),
-  [ChainId.SEPOLIA]: CurrencyAmount.fromRawAmount(USDC_SEPOLIA, 10_000e6),
-  [ChainId.OPTIMISM_GOERLI]: CurrencyAmount.fromRawAmount(USDC_OPTIMISM_GOERLI, 10_000e6),
-  [ChainId.ARBITRUM_GOERLI]: CurrencyAmount.fromRawAmount(USDC_ARBITRUM_GOERLI, 10_000e6),
-  [ChainId.POLYGON_MUMBAI]: CurrencyAmount.fromRawAmount(USDC_POLYGON_MUMBAI, 10_000e6),
-  [ChainId.CELO_ALFAJORES]: CurrencyAmount.fromRawAmount(CUSD_CELO_ALFAJORES, 10_000e6),
   [ChainId.HEMI_SEPOLIA]: CurrencyAmount.fromRawAmount(DAI_HEMI_SEPOLIA, 10_000e18),
 }
 

--- a/apps/web/src/lib/hooks/useCurrencyLogoURIs.ts
+++ b/apps/web/src/lib/hooks/useCurrencyLogoURIs.ts
@@ -2,58 +2,26 @@ import { ChainId } from '@uniswap/sdk-core'
 import useHttpLocations from 'hooks/useHttpLocations'
 import { useMemo } from 'react'
 import { isAddress } from 'utilities/src/addresses'
-
-import EthereumLogo from '../../assets/images/ethereum-logo.png'
-import AvaxLogo from '../../assets/svg/avax_logo.svg'
-import BnbLogo from '../../assets/svg/bnb-logo.svg'
-import CeloLogo from '../../assets/svg/celo_logo.svg'
-import MaticLogo from '../../assets/svg/matic-token-icon.svg'
 import HemiEthLogo from '../../assets/svg/hemi-logo.svg'
-import { NATIVE_CHAIN_ID, isCelo, nativeOnChain } from '../../constants/tokens'
+import { NATIVE_CHAIN_ID } from '../../constants/tokens'
 
-type Network = 'ethereum' | 'arbitrum' | 'optimism' | 'polygon' | 'smartchain' | 'celo' | 'avalanchec' | 'base' | 'hemi sepolia'
+type Network = 'hemi sepolia'
 
 export function chainIdToNetworkName(networkId: ChainId): Network {
   switch (networkId) {
-    case ChainId.MAINNET:
-      return 'ethereum'
-    case ChainId.ARBITRUM_ONE:
-      return 'arbitrum'
-    case ChainId.OPTIMISM:
-      return 'optimism'
-    case ChainId.POLYGON:
-      return 'polygon'
-    case ChainId.BNB:
-      return 'smartchain'
-    case ChainId.CELO:
-      return 'celo'
-    case ChainId.AVALANCHE:
-      return 'avalanchec'
-    case ChainId.BASE:
-      return 'base'
     case ChainId.HEMI_SEPOLIA:
       return 'hemi sepolia'
     default:
-      return 'ethereum'
+      return 'hemi sepolia'
   }
 }
 
 export function getNativeLogoURI(chainId: ChainId = ChainId.MAINNET): string {
   switch (chainId) {
-    case ChainId.POLYGON:
-    case ChainId.POLYGON_MUMBAI:
-      return MaticLogo
-    case ChainId.BNB:
-      return BnbLogo
-    case ChainId.CELO:
-    case ChainId.CELO_ALFAJORES:
-      return CeloLogo
-    case ChainId.AVALANCHE:
-      return AvaxLogo
     case ChainId.HEMI_SEPOLIA:
         return HemiEthLogo
     default:
-      return EthereumLogo
+      return HemiEthLogo
   }
 }
 
@@ -67,9 +35,6 @@ function getTokenLogoURI(address: string, chainId: ChainId = ChainId.MAINNET): s
     ChainId.AVALANCHE,
     ChainId.BASE,
   ]
-  if (isCelo(chainId) && address === nativeOnChain(chainId).wrapped.address) {
-    return CeloLogo
-  }
 
   if (networksWithUrls.includes(chainId)) {
     return `https://raw.githubusercontent.com/Uniswap/assets/master/blockchains/${networkName}/assets/${address}/logo.png`

--- a/apps/web/src/state/stake/hooks.tsx
+++ b/apps/web/src/state/stake/hooks.tsx
@@ -1,6 +1,6 @@
 import { Interface } from '@ethersproject/abi'
 import StakingRewardsJSON from '@uniswap/liquidity-staker/build/StakingRewards.json'
-import { ChainId, CurrencyAmount, Token } from '@uniswap/sdk-core'
+import { CurrencyAmount, Token } from '@uniswap/sdk-core'
 import { Pair } from '@uniswap/v2-sdk'
 import { useWeb3React } from '@web3-react/core'
 import useCurrentBlockTimestamp from 'hooks/useCurrentBlockTimestamp'
@@ -8,7 +8,7 @@ import JSBI from 'jsbi'
 import { NEVER_RELOAD, useMultipleContractSingleData } from 'lib/hooks/multicall'
 import { useMemo } from 'react'
 
-import { DAI, UNI, USDC_MAINNET, USDT, WBTC, WRAPPED_NATIVE_CURRENCY } from '../../constants/tokens'
+import { UNI } from '../../constants/tokens'
 
 const STAKING_REWARDS_INTERFACE = new Interface(StakingRewardsJSON.abi)
 
@@ -20,24 +20,7 @@ const STAKING_REWARDS_INFO: {
     stakingRewardAddress: string
   }[]
 } = {
-  1: [
-    {
-      tokens: [WRAPPED_NATIVE_CURRENCY[ChainId.MAINNET] as Token, DAI],
-      stakingRewardAddress: '0xa1484C3aa22a66C62b77E0AE78E15258bd0cB711',
-    },
-    {
-      tokens: [WRAPPED_NATIVE_CURRENCY[ChainId.MAINNET] as Token, USDC_MAINNET],
-      stakingRewardAddress: '0x7FBa4B8Dc5E7616e59622806932DBea72537A56b',
-    },
-    {
-      tokens: [WRAPPED_NATIVE_CURRENCY[ChainId.MAINNET] as Token, USDT],
-      stakingRewardAddress: '0x6C3e4cb2E96B01F4b866965A91ed4437839A121a',
-    },
-    {
-      tokens: [WRAPPED_NATIVE_CURRENCY[ChainId.MAINNET] as Token, WBTC],
-      stakingRewardAddress: '0xCA35e32e7926b96A9988f61d510E038108d8068e',
-    },
-  ],
+  1: [],
 }
 
 interface StakingInfo {

--- a/apps/web/src/utils/nativeTokens.ts
+++ b/apps/web/src/utils/nativeTokens.ts
@@ -1,4 +1,3 @@
-import { MATIC_POLYGON, nativeOnChain } from 'constants/tokens'
 import { Chain } from 'graphql/data/__generated__/types-and-hooks'
 import { supportedChainIdFromGQLChain } from 'graphql/data/util'
 
@@ -8,17 +7,6 @@ export function getNativeTokenDBAddress(chain: Chain): string | undefined {
     return undefined
   }
   switch (chain) {
-    // Celo & Polygon have precompiles for their native tokens
-    case Chain.Celo:
-      return nativeOnChain(pageChainId).wrapped.address
-    case Chain.Polygon:
-      // Like Celo, native MATIC does have a ERC20 precompile, but we use WMATIC in routing/pools
-      // So instead of returning nativeOnChain().wrapped.address, should directly use the precompile address here
-      return MATIC_POLYGON.address
-    case Chain.Ethereum:
-    case Chain.Arbitrum:
-    case Chain.EthereumGoerli:
-    case Chain.Optimism:
     default:
       return undefined
   }


### PR DESCRIPTION
This PR adds USDC.e and USDT.e tokens available to select them from the swap form. 
They are searchable from the input in the token selection modal, and they can be pinned as the most commonly used. I pinned only USDC.e for now.

It also cleans up most places that referenced unused tokens from unused chains.

## Screenshots

Here's a swap from USDC.e to ETH:

https://github.com/hemilabs/interface/assets/1864435/9f5ca89d-68c4-43e1-b910-17eb9dc24c8a


And a swap from USDT.e to ETH:

https://github.com/hemilabs/interface/assets/1864435/cd57e150-4d8c-4cd0-bf42-3b7675edea24



