### PR TITLE
Deploy uniswap at swap.hemi.xyz

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -26,6 +26,8 @@ jobs:
         run: |
           cd apps/web
           yarn run build:production
+        end:
+          PUBLIC_URL: "."
 
       - name: Copy files to Hostinger
         uses: appleboy/scp-action@master

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -3,7 +3,6 @@
   "version": "1.1.0",
   "description": "Uniswap Interface",
   "license": "GPL-3.0-or-later",
-  "homepage": "/swap",
   "scripts": {
     "ajv": "node scripts/compile-ajv-validators.js",
     "check:deps:usage": "depcheck",

--- a/apps/web/src/utils/env.ts
+++ b/apps/web/src/utils/env.ts
@@ -16,7 +16,7 @@ export function isProductionEnv(): boolean {
 }
 
 export function isAppHemiXyz({ hostname }: { hostname: string }): boolean {
-  return hostname === 'hemi.xyz'
+  return hostname === 'swap.hemi.xyz'
 }
 
 export function isBrowserRouterEnabled(): boolean {


### PR DESCRIPTION
Related to #41

It removes the PATH configuration that was deploying in `/swap`. According to create-react-docs (which is used by CRACO), `PUBLIC_URL` as the env variable, and `homepage` in the `package.json` are the variables used for defining subpaths. See [docs](https://create-react-app.dev/docs/advanced-configuration/).

With homepage removed, and the usage of `PUBLIC_URL` to the root, it should work

I also updated `isAppHemiXyz` because hostname includes subdomains 