### PR TITLE
Fix PUBLIC_URL in uniswap

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -27,7 +27,7 @@ jobs:
           cd apps/web
           yarn run build:production
         env:
-          PUBLIC_URL: "."
+          PUBLIC_URL: ""
 
       - name: Copy files to Hostinger
         uses: appleboy/scp-action@master

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -19,7 +19,7 @@
     "i18n:compile": "lingui compile",
     "i18n": "yarn i18n:extract --clean && yarn i18n:compile",
     "prepare": "concurrently \"npm:ajv\" \"npm:i18n\"",
-    "start": "PUBLIC_URL=\".\" craco start",
+    "start": "PUBLIC_URL=\"\" craco start",
     "start:cloud": "NODE_OPTIONS=--dns-result-order=ipv4first PORT=3001 npx wrangler pages dev --compatibility-flags=nodejs_compat --compatibility-date=2023-08-01 --proxy=3001 --port=3000 -- yarn start",
     "build:production": "craco build",
     "analyze": "source-map-explorer 'build/static/js/*.js' --no-border-checks --gzip",


### PR DESCRIPTION
Related to #41 

It seems that using `PUBLIC_URL` with `.` causes the `<base>` tag in the HTML to be `./` and that breaks some file downloading (but not others!). If we set `PUBLIC_URL` to `''` (Empty string), it defaults to `/` which seems to be working, at least locally. The last option would be to revert the changes and not use `PUBLIC_URL` at all. I went for `.` because that was what was defined in the package.json originally