### PR TITLE
Temporarily fix token selection lists

### DIFF
--- a/apps/web/src/components/SearchModal/useCurrencySearchResults.ts
+++ b/apps/web/src/components/SearchModal/useCurrencySearchResults.ts
@@ -74,7 +74,10 @@ export function useCurrencySearchResults({
       // If there is no query, filter out unselected user-added tokens with no balance.
       if (!searchQuery && token instanceof UserAddedToken) {
         if (selectedCurrency?.equals(token) || otherSelectedCurrency?.equals(token)) return true
-        return balanceMap[token.address.toLowerCase()]?.usdValue > 0
+        // In Hemi, obtaining the USD value of a token is mostly not possible
+        // due to the lack of routes, etc. This fact affects the token lists,
+        // like by triggering the condition below. Therefore, it was hacked.
+        return true // balanceMap[token.address.toLowerCase()]?.usdValue > 0
       }
 
       return true


### PR DESCRIPTION
This PR removes a check that filters out user tokens with no USD balance from the token selection lists during swap. Since there is no way to calculate USD values in Hemi [yet], all user tokens were removed regardless having balance.

Closes #45.