### PR TITLE
Use the public Hemi Sepolia RPC URL

### DIFF
--- a/apps/web/src/constants/networks.ts
+++ b/apps/web/src/constants/networks.ts
@@ -126,7 +126,7 @@ export const PUBLIC_RPC_URLS: Record<SupportedInterfaceChain, string[]> = {
   ],
   [ChainId.HEMI_SEPOLIA]: [
     // "Safe" URLs
-    'https://int02.testnet.rpc.hemi.network/rpc' 
+    'https://testnet.rpc.hemi.network/rpc'
   ]
 }
 


### PR DESCRIPTION
The default RPC URL was restored.